### PR TITLE
analytics cli: disable positional args

### DIFF
--- a/pkg/analytics/cli.go
+++ b/pkg/analytics/cli.go
@@ -53,6 +53,8 @@ func NewCommand() *cobra.Command {
 		Use:   "analytics",
 		Short: "info and status about windmill analytics",
 		RunE:  analyticsStatus,
+		DisableFlagsInUseLine: true,
+		Args: cobra.NoArgs,
 	}
 
 	opt := &cobra.Command{


### PR DESCRIPTION
old:
```
$ tilt analytics opt-in
analytics status : default
```
(the "opt-in" is silently ignored and the command functions the same as `tilt analytics`)

new:
```
$ tilt analytics opt-in
Error: unknown command "opt-in" for "tilt analytics"
Usage:
  tilt analytics
  tilt analytics [command]

Available Commands:
  opt         opt-in or -out to windmill analytics collection/upload
```