### PR TITLE
prefer ~/.tilt-dev over ~/.windmill, now that we don't go by tilt-dev anymore

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,12 @@ module github.com/tilt-dev/wmclient
 
 require (
 	github.com/denisbrodbeck/machineid v1.0.0
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/mitchellh/go-homedir v1.1.0
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.3 // indirect
 	github.com/stretchr/testify v1.3.0
+	golang.org/x/sys v0.0.0-20201106081118-db71ae66460a // indirect
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,10 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/denisbrodbeck/machineid v1.0.0 h1:6tMg1EaB3r/EfIqKS0on/pvkRBZJAXH3fmSLGi8SWf0=
 github.com/denisbrodbeck/machineid v1.0.0/go.mod h1:dJUwb7PTidGDeYyUBmXZ2GphQBbjJCrnectwCyxcUSI=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
+github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
+github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/spf13/cobra v0.0.3 h1:ZlrZ4XsMRm04Fr5pSFxBgfND2EBVa1nLpiy1stUsX/8=
@@ -11,3 +15,5 @@ github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+golang.org/x/sys v0.0.0-20201106081118-db71ae66460a h1:ALUFBKlIyeY7y5ZgPJmblk/vKz+zBQSnNiPkt41sgeg=
+golang.org/x/sys v0.0.0-20201106081118-db71ae66460a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/analytics/cli.go
+++ b/pkg/analytics/cli.go
@@ -38,7 +38,7 @@ func analyticsOpt(_ *cobra.Command, args []string) (outerErr error) {
 	if err != nil {
 		return err
 	}
-	d, err := dirs.UseWindmillDir()
+	d, err := dirs.UseTiltDevDir()
 	if err != nil {
 		return err
 	}
@@ -50,16 +50,16 @@ const choiceFile = "analytics/user/choice.txt"
 
 func NewCommand() *cobra.Command {
 	analytics := &cobra.Command{
-		Use:   "analytics",
-		Short: "info and status about windmill analytics",
-		RunE:  analyticsStatus,
+		Use:                   "analytics",
+		Short:                 "info and status about tilt-dev analytics",
+		RunE:                  analyticsStatus,
 		DisableFlagsInUseLine: true,
-		Args: cobra.NoArgs,
+		Args:                  cobra.NoArgs,
 	}
 
 	opt := &cobra.Command{
 		Use:   "opt",
-		Short: "opt-in or -out to windmill analytics collection/upload",
+		Short: "opt-in or -out to tilt-dev analytics collection/upload",
 		RunE:  analyticsOpt,
 	}
 	analytics.AddCommand(opt)

--- a/pkg/analytics/opt.go
+++ b/pkg/analytics/opt.go
@@ -69,7 +69,7 @@ func SetOptStr(s string) (Opt, error) {
 func SetOpt(c Opt) error {
 	s := c.String()
 
-	d, err := dirs.UseWindmillDir()
+	d, err := dirs.UseTiltDevDir()
 	if err != nil {
 		return err
 	}
@@ -82,7 +82,7 @@ func SetOpt(c Opt) error {
 }
 
 func readChoiceFile() (string, error) {
-	d, err := dirs.UseWindmillDir()
+	d, err := dirs.UseTiltDevDir()
 	if err != nil {
 		return "", err
 	}

--- a/pkg/dirs/dirs.go
+++ b/pkg/dirs/dirs.go
@@ -4,31 +4,24 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/user"
 	"path/filepath"
+
+	"github.com/mitchellh/go-homedir"
 )
 
-func CurrentHomeDir() (string, error) {
-	home := os.Getenv("HOME")
-	if home != "" {
-		return home, nil
-	}
-
-	current, err := user.Current()
-	if err != nil {
-		return "", err
-	}
-	return current.HomeDir, nil
-}
-
-// WindmillDir returns the root Windmill directory; by default ~/.windmill
-func GetWindmillDir() (string, error) {
+// TiltDevDir returns the root settings directory.
+// For legacy reasons, we use ~/.windmill if it exists.
+// Otherwise, we use ~/.tilt-dev
+func GetTiltDevDir() (string, error) {
 	dir := os.Getenv("WMDAEMON_HOME")
 	if dir == "" {
 		dir = os.Getenv("WINDMILL_DIR")
 	}
 	if dir == "" {
-		homedir, err := CurrentHomeDir()
+		dir = os.Getenv("TILT_DEV_DIR")
+	}
+	if dir == "" {
+		homedir, err := homedir.Dir()
 		if err != nil {
 			return "", err
 		}
@@ -37,6 +30,14 @@ func GetWindmillDir() (string, error) {
 			return "", fmt.Errorf("Cannot find home directory; $HOME unset")
 		}
 		dir = filepath.Join(homedir, ".windmill")
+		if _, err := os.Stat(dir); err != nil {
+			if os.IsNotExist(err) {
+				dir = filepath.Join(homedir, ".tilt-dev")
+			} else if err != nil {
+				return "", err
+			}
+		}
+
 	}
 
 	dir, err := filepath.Abs(dir)
@@ -55,29 +56,29 @@ func GetWindmillDir() (string, error) {
 	return dir, nil
 }
 
-func UseWindmillDir() (*WindmillDir, error) {
-	dir, err := GetWindmillDir()
+func UseTiltDevDir() (*TiltDevDir, error) {
+	dir, err := GetTiltDevDir()
 	if err != nil {
 		return nil, err
 	}
 
-	return &WindmillDir{dir: dir}, nil
+	return &TiltDevDir{dir: dir}, nil
 }
 
 // Create a windmill dir at an arbitrary directory. Useful for testing.
-func NewWindmillDirAt(dir string) *WindmillDir {
-	return &WindmillDir{dir: dir}
+func NewTiltDevDirAt(dir string) *TiltDevDir {
+	return &TiltDevDir{dir: dir}
 }
 
-type WindmillDir struct {
+type TiltDevDir struct {
 	dir string
 }
 
-func (d *WindmillDir) Root() string {
+func (d *TiltDevDir) Root() string {
 	return d.dir
 }
 
-func (d *WindmillDir) OpenFile(p string, flag int, perm os.FileMode) (*os.File, error) {
+func (d *TiltDevDir) OpenFile(p string, flag int, perm os.FileMode) (*os.File, error) {
 	err := d.MkdirAll(filepath.Dir(p))
 	if err != nil {
 		return nil, err
@@ -86,7 +87,7 @@ func (d *WindmillDir) OpenFile(p string, flag int, perm os.FileMode) (*os.File, 
 	return os.OpenFile(filepath.Join(d.dir, p), flag, perm)
 }
 
-func (d *WindmillDir) WriteFile(p, text string) error {
+func (d *TiltDevDir) WriteFile(p, text string) error {
 	err := d.MkdirAll(filepath.Dir(p))
 	if err != nil {
 		return err
@@ -95,9 +96,9 @@ func (d *WindmillDir) WriteFile(p, text string) error {
 	return ioutil.WriteFile(filepath.Join(d.dir, p), []byte(text), os.FileMode(0700))
 }
 
-func (d *WindmillDir) ReadFile(p string) (string, error) {
+func (d *TiltDevDir) ReadFile(p string) (string, error) {
 	if filepath.IsAbs(p) {
-		return "", fmt.Errorf("WindmillDir.ReadFile: p must be relative to .windmill root: %v", p)
+		return "", fmt.Errorf("TiltDevDir.ReadFile: p must be relative to .tilt-dev root: %v", p)
 	}
 
 	abs := filepath.Join(d.dir, p)
@@ -109,17 +110,17 @@ func (d *WindmillDir) ReadFile(p string) (string, error) {
 	return string(bs), nil
 }
 
-func (d *WindmillDir) MkdirAll(p string) error {
+func (d *TiltDevDir) MkdirAll(p string) error {
 	if filepath.IsAbs(p) {
-		return fmt.Errorf("WindmillDir.MkdirAll: p must be relative to .windmill root: %v", p)
+		return fmt.Errorf("TiltDevDir.MkdirAll: p must be relative to .tilt-dev root: %v", p)
 	}
 
 	return os.MkdirAll(filepath.Join(d.dir, p), os.FileMode(0700))
 }
 
-func (d *WindmillDir) Abs(p string) (string, error) {
+func (d *TiltDevDir) Abs(p string) (string, error) {
 	if filepath.IsAbs(p) {
-		return "", fmt.Errorf("WindmillDir.Abs: p must be relative to .windmill root: %v", p)
+		return "", fmt.Errorf("TiltDevDir.Abs: p must be relative to .tilt-dev root: %v", p)
 	}
 
 	return filepath.Join(d.dir, p), nil

--- a/pkg/dirs/dirs.go
+++ b/pkg/dirs/dirs.go
@@ -13,12 +13,12 @@ import (
 // For legacy reasons, we use ~/.windmill if it exists.
 // Otherwise, we use ~/.tilt-dev
 func GetTiltDevDir() (string, error) {
-	dir := os.Getenv("WMDAEMON_HOME")
+	dir := os.Getenv("TILT_DEV_DIR")
 	if dir == "" {
-		dir = os.Getenv("WINDMILL_DIR")
+		dir = os.Getenv("WMDAEMON_HOME")
 	}
 	if dir == "" {
-		dir = os.Getenv("TILT_DEV_DIR")
+		dir = os.Getenv("WINDMILL_DIR")
 	}
 	if dir == "" {
 		homedir, err := homedir.Dir()
@@ -65,7 +65,7 @@ func UseTiltDevDir() (*TiltDevDir, error) {
 	return &TiltDevDir{dir: dir}, nil
 }
 
-// Create a windmill dir at an arbitrary directory. Useful for testing.
+// Create a .tilt-dev dir at an arbitrary directory. Useful for testing.
 func NewTiltDevDirAt(dir string) *TiltDevDir {
 	return &TiltDevDir{dir: dir}
 }

--- a/pkg/dirs/dirs_test.go
+++ b/pkg/dirs/dirs_test.go
@@ -8,14 +8,14 @@ import (
 	"testing"
 )
 
-func TestWindmillDir(t *testing.T) {
+func TestTiltDevDir(t *testing.T) {
 	emptyPath := ""
 	oldWmdaemonHome := os.Getenv("WMDAEMON_HOME")
 	oldHome := os.Getenv("HOME")
-	oldWindmillDir := os.Getenv("WINDMILL_DIR")
+	oldTiltDevDir := os.Getenv("WINDMILL_DIR")
 	defer os.Setenv("WMDAEMON_HOME", oldWmdaemonHome)
 	defer os.Setenv("HOME", oldHome)
-	defer os.Setenv("WINDMILL_DIR", oldWindmillDir)
+	defer os.Setenv("WINDMILL_DIR", oldTiltDevDir)
 	tmpHome := os.TempDir()
 
 	f := setup(t)
@@ -23,28 +23,31 @@ func TestWindmillDir(t *testing.T) {
 	os.Setenv("HOME", tmpHome)
 
 	os.Setenv("WMDAEMON_HOME", emptyPath)
-	f.assertWindmillDir(path.Join(tmpHome, ".windmill"), "empty WMDAEMON_HOME")
+	f.assertTiltDevDir(path.Join(tmpHome, ".tilt-dev"), "empty .windmill")
+
+	os.Mkdir(filepath.Join(tmpHome, ".windmill"), 0755)
+	f.assertTiltDevDir(path.Join(tmpHome, ".windmill"), "populated .windmill")
 
 	tmpWmdaemonHome := os.TempDir()
 	os.Setenv("WMDAEMON_HOME", tmpWmdaemonHome)
-	f.assertWindmillDir(tmpWmdaemonHome, "tmp WMDAEMON_HOME")
+	f.assertTiltDevDir(tmpWmdaemonHome, "tmp WMDAEMON_HOME")
 
 	nonExistentWmdaemonHome := path.Join(tmpWmdaemonHome, "foo")
 	os.Setenv("WMDAEMON_HOME", nonExistentWmdaemonHome)
-	f.assertWindmillDir(nonExistentWmdaemonHome, "nonexistent WMDAEMON_HOME")
+	f.assertTiltDevDir(nonExistentWmdaemonHome, "nonexistent WMDAEMON_HOME")
 
 	wmDir := os.TempDir()
 	os.Setenv("WINDMILL_DIR", wmDir)
-	f.assertWindmillDir(nonExistentWmdaemonHome, "prefer WMDAEMON_HOME") // prefer WMDAEMON_HOME
+	f.assertTiltDevDir(nonExistentWmdaemonHome, "prefer WMDAEMON_HOME") // prefer WMDAEMON_HOME
 
 	os.Unsetenv("WMDAEMON_HOME")
-	f.assertWindmillDir(wmDir, "no WMDAEMON_HOME")
+	f.assertTiltDevDir(wmDir, "no WMDAEMON_HOME")
 }
 
 func TestOpenFile(t *testing.T) {
 	tmp, _ := ioutil.TempDir("", t.Name())
 	defer os.RemoveAll(tmp)
-	dir := NewWindmillDirAt(tmp)
+	dir := NewTiltDevDirAt(tmp)
 
 	fp, err := dir.OpenFile("inner/a.txt", os.O_WRONLY|os.O_CREATE, os.FileMode(0700))
 	if err != nil {
@@ -72,8 +75,8 @@ func setup(t *testing.T) *fixture {
 	return &fixture{t: t}
 }
 
-func (f *fixture) assertWindmillDir(expected, testCase string) {
-	actual, err := GetWindmillDir()
+func (f *fixture) assertTiltDevDir(expected, testCase string) {
+	actual, err := GetTiltDevDir()
 	if err != nil {
 		f.t.Error(err)
 	}

--- a/pkg/dirs/dirs_test.go
+++ b/pkg/dirs/dirs_test.go
@@ -6,17 +6,22 @@ import (
 	"path"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestTiltDevDir(t *testing.T) {
 	emptyPath := ""
 	oldWmdaemonHome := os.Getenv("WMDAEMON_HOME")
 	oldHome := os.Getenv("HOME")
-	oldTiltDevDir := os.Getenv("WINDMILL_DIR")
+	oldWindmillDir := os.Getenv("WINDMILL_DIR")
+	oldTiltDevDir := os.Getenv("TILT_DEV_DIR")
 	defer os.Setenv("WMDAEMON_HOME", oldWmdaemonHome)
 	defer os.Setenv("HOME", oldHome)
-	defer os.Setenv("WINDMILL_DIR", oldTiltDevDir)
-	tmpHome := os.TempDir()
+	defer os.Setenv("WINDMILL_DIR", oldWindmillDir)
+	defer os.Setenv("TILT_DEV_DIR", oldTiltDevDir)
+	tmpHome, err := ioutil.TempDir("", t.Name())
+	require.NoError(t, err)
 
 	f := setup(t)
 
@@ -42,6 +47,10 @@ func TestTiltDevDir(t *testing.T) {
 
 	os.Unsetenv("WMDAEMON_HOME")
 	f.assertTiltDevDir(wmDir, "no WMDAEMON_HOME")
+
+	tiltDevDir := os.TempDir()
+	os.Setenv("TILT_DEV_DIR", tiltDevDir)
+	f.assertTiltDevDir(tiltDevDir, "TILT_DEV_DIR has precedence")
 }
 
 func TestOpenFile(t *testing.T) {
@@ -88,6 +97,6 @@ func (f *fixture) assertTiltDevDir(expected, testCase string) {
 	}
 
 	if actual != absExpected {
-		f.t.Errorf("[TEST CASE: %s] got windmill dir %q; expected %q", testCase, actual, absExpected)
+		f.t.Errorf("[TEST CASE: %s] got dir %q; expected %q", testCase, actual, absExpected)
 	}
 }


### PR DESCRIPTION
Hello @landism, @maiamcc,

Please review the following commits I made in branch nicks/tilt-dev:

4e865e3b6c2a985fc30472dc1c6f4849f44b64c5 (2020-11-06 17:16:34 -0500)
prefer ~/.tilt-dev over ~/.windmill, now that we don't go by tilt-dev anymore

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics